### PR TITLE
Rename package to jsog-typescript

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,7 @@ build:
     when: on_success
     expire_in: 1 week
     paths:
-    - jsog-ts-*.tgz
+    - jsog-typescript-*.tgz
 
 test:
   stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ deploy:
     secure: EkoXfGTgycBZZf6J1YvW937PRnqxHJ78bwOYG1/sB6khhh6aHPDkLEAZWf+X5dnj4MmfUfNdd1UdZKqxhx+GBTdaqQsgYruNbxkfuA/UpiqGN59P5vWz15NFl9sXJPzBIUQR9Mh2fKmzCjvvn0sKQo/oENx8/5k28MU4pZNYHUI2US0mhKRwp7JF+zrVrnsbqGnmZtuLMWONTfrMUhM6tKhPWzAFKAjVLTNWYYyvD4etv2CBk4uCWXVwQMYrp13lXjpl6sLyWTQrUS/hopRcE9R001O044kPR1TmfLj98XkXEo+Uwin/3nnTL0z3OzswGX/UnOXLsTtqvY4QZeTBa0lmrJHYinXb7rSUIXePC+yZEKyU4kjQwMzNDqlhhmVJKQBNLEBXygKxCfPKT10WFK2Vk4y+p+drvD8OSuZqLJY3fDjjPeDTZ7DbaFIfA0140pyl8Ya1hpuJW2wddnH3V2mISObH+1zklyZNJj2+dptSohG4YcyjVCNKMNLxmtV6ApMXt/hIiJDELSs40lKw8H7mOq/gZjfMOxEJw14aYmmDBhmJS/+Q35gYb4Ztls/sj6ad6AkLcYx8kKG6gjf3wXS+nwX1c6eF4zKDiAReR4t52Hv9scj4zfEj+0tP2pXk6gv2ab1f08DOgz8Eo44Un6ncTUzl8TSV57YUtt8gFNY=
   on:
     tags: true
-    repo: e-mundo/jsog-ts
+    repo: e-mundo/jsog-typescript

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is able to instantiante typescript objects during deserialization.
 ### Installation
 
 ```
-npm --save jsog-ts
+npm --save jsog-typescript
 ```
 
 Enable typescript `experimentalDecorator` and `emitDecoratorMetadata` compiler options.
@@ -28,7 +28,7 @@ Minimal tslint.json:
 Generate a new instance of the service. See Integration for integration to some popular frameworks.
 
 ```
-import { jsogService } from 'jsog-ts'
+import { jsogService } from 'jsog-typescript'
 
 const jsog = new JsogService();
 ```
@@ -59,7 +59,7 @@ Provide JsogService as an Angular 4 Service which can be injected into your Comp
 
 ```
 import { NgModule } from '@angular/core';
-import { JsogService } from 'jsog-ts';
+import { JsogService } from 'jsog-typescript';
 
 @NgModule({
     providers: [
@@ -74,7 +74,7 @@ Register JsogService as an Angular Service
 
 ```
 import { module } from 'angular';
-import { JsogService } from 'jsog-ts';
+import { JsogService } from 'jsog-typescript';
 
 module.service('JsogService', JsogService)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jsog-ts",
+  "name": "jsog-typescript",
   "version": "1.0.0-0",
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jsog-ts",
+  "name": "jsog-typescript",
   "version": "1.0.0-0",
   "description": "JavaScript Object Graphs with Typescript",
   "main": "./dist/index.js",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/e-mundo/jsog-ts.git"
+    "url": "https://github.com/e-mundo/jsog-typescript.git"
   },
   "keywords": [
     "typescript",


### PR DESCRIPTION
This is required because there is already a package named jsog-ts published in npm.

We do not contribute to this package for this reasons:
1. It is forked off jsog/jsog but does not do the same.
2. It uses way to complex annotations.